### PR TITLE
Add OctoLinker

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ The second, older syntax is known as the indented syntax (or just "Sass"). Inspi
 - [Scout-App](http://scout-app.io/) - Process your Sass and SCSS files into CSS without needing any knowledge of the command line.
 - [sass-rails](https://github.com/rails/sass-rails) - Ruby on Rails stylesheet engine for Sass.
 - [scss-lint](https://github.com/brigade/scss-lint) - Configurable tool for writing clean and consistent SCSS.
+- [github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension) - Navigate through *.scss files efficiently with the OctoLinker browser extension for GitHub.
 
 ## Books
 - [Sass in the Real World: Book I of IV](https://anotheruiguy.gitbooks.io/sassintherealworld_book-i/content/)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The second, older syntax is known as the indented syntax (or just "Sass"). Inspi
 - [Scout-App](http://scout-app.io/) - Process your Sass and SCSS files into CSS without needing any knowledge of the command line.
 - [sass-rails](https://github.com/rails/sass-rails) - Ruby on Rails stylesheet engine for Sass.
 - [scss-lint](https://github.com/brigade/scss-lint) - Configurable tool for writing clean and consistent SCSS.
-- [github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension) - Navigate through *.scss files efficiently with the OctoLinker browser extension for GitHub.
+- [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through *.scss and *.sass files efficiently with the OctoLinker browser extension for GitHub.
 
 ## Books
 - [Sass in the Real World: Book I of IV](https://anotheruiguy.gitbooks.io/sassintherealworld_book-i/content/)


### PR DESCRIPTION
Tools / browser extension [github.com/OctoLinker/browser-extension](https://github.com/OctoLinker/browser-extension)

> Navigate through projects on GitHub.com efficiently with the OctoLinker browser extension.

Most projects consist of many files and third party dependencies. Files are referencing other files and / or dependencies by language specific statements like include or require. The OctoLinker browser extension makes these references clickable. In the latest version we added support for Sass.

## Demo

![sass](https://cloud.githubusercontent.com/assets/1393946/24168931/48582c74-0e7c-11e7-9c34-3be2361fc87a.gif)
