### PR TITLE
Add node-sass-magic-importer to the Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The second, older syntax is known as the indented syntax (or just "Sass"). Inspi
 - [OctoLinker](https://github.com/OctoLinker/browser-extension) - Navigate through *.scss and *.sass files efficiently with the OctoLinker browser extension for GitHub.
 - [stylelint](https://stylelint.io/) - A mighty, modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets. Supports CSS-like syntaxes, including SCSS.
 - [diamond](https://diamond.js.org) - Dependency management built for Sass, Less, and CSS.
+- [node-sass-magic-importer](https://github.com/maoberlehner/node-sass-magic-importer) - Custom node-sass importer for selector specific imports, node importing, module importing, globbing support and importing files only once.
 
 ## Books
 - [Sass in the Real World: Book I of IV](https://anotheruiguy.gitbooks.io/sassintherealworld_book-i/content/)


### PR DESCRIPTION
node-sass-magic-importer is a custom importer for node-sass to enable a lot of extra features to enhance the `@import` function.