### PR TITLE
Add sass-planifola to color section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The second, older syntax is known as the indented syntax (or just "Sass"). Inspi
 - [scss-blend-modes](https://github.com/heygrady/scss-blend-modes) - Using standard color blending functions in Sass.
 - [brand-colors](http://brand-colors.com/) - 1100+ collection of popular brand colors available in Sass, Less, Stylus and CSS.
 - [Open color](https://github.com/yeun/open-color) - Open color is a color scheme for UI design. Available in CSS, SCSS, LESS, Stylus, Adobe library, Photoshop/Illustrator swatches and Sketch palette.
+- [sass-planifolia](https://github.com/xi/sass-planifolia) - Advanced color manipulation and contrast calculation in vanilla Sass.
 
 ### Typography
 - [Sassline](https://sassline.com/) - Set text on the web to a baseline grid with Sass & rems using a responsive modular-scale.


### PR DESCRIPTION
The main focus of that library is color-related, but it also contains some other things. I still think it would be best to have it in the color section.