### PR TITLE
Updated website for brand-colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The second, older syntax is known as the indented syntax (or just "Sass"). Inspi
 - [Sass MQ](https://github.com/sass-mq/sass-mq) - Sass mixin that helps you compose media queries in an elegant way.
 
 ### Color
-- [brand-colors](http://brand-colors.com/) - 1100+ collection of popular brand colors available in Sass, Less, Stylus and CSS.
+- [brand-colors](https://brand-colors.re.im/) - 1100+ collection of popular brand colors available in Sass, Less, Stylus and CSS.
 - [Open color](https://github.com/yeun/open-color) - Open color is a color scheme for UI design. Available in CSS, SCSS, LESS, Stylus, Adobe library, Photoshop/Illustrator swatches and Sketch palette.
 - [sass-planifolia](https://github.com/xi/sass-planifolia) - Advanced color manipulation and contrast calculation in vanilla Sass.
 - [scss-blend-modes](https://github.com/heygrady/scss-blend-modes) - Using standard color blending functions in Sass.


### PR DESCRIPTION
According to [this issue](https://github.com/reimertz/brand-colors/issues/64) the owner of the repo lost his domain and switched to a new one. The old website shows at the moment some part of the page, but all the CSS is missing. It would be good to update the readme to the new URL.